### PR TITLE
Minor fixes

### DIFF
--- a/src/js/db.js
+++ b/src/js/db.js
@@ -24,7 +24,7 @@ db = [
     {
         added: 'Jul 9, 2020',
         category: 'inspirations',
-        description: 'dribble',
+        description: 'dribbble',
         link: 'https://dribbble.com/',
         new: false
     },

--- a/src/scss/_general.scss
+++ b/src/scss/_general.scss
@@ -35,6 +35,12 @@ main {
     background-image: url('../assets/svg/grey-lines-bg.svg');
     background-size: cover;
     background-attachment: fixed;
+
+    @media (max-width: 767px) {
+        background-attachment: initial;
+        background-image: none;
+        background-color: $grey-15;
+    }
 }
 
 .fet-section {

--- a/src/scss/_tiles.scss
+++ b/src/scss/_tiles.scss
@@ -34,7 +34,7 @@
     opacity: 1;
 
     &--fade-out {
-        transform: translateY(150px);
+        transform: translateY(200px);
         opacity: 0;
     }
 

--- a/src/scss/main.css
+++ b/src/scss/main.css
@@ -232,6 +232,13 @@ main {
   background-size: cover;
   background-attachment: fixed;
 }
+@media (max-width: 767px) {
+  main {
+    background-attachment: initial;
+    background-image: none;
+    background-color: #262626;
+  }
+}
 
 .fet-section {
   max-width: 1200px;
@@ -401,7 +408,7 @@ footer {
   opacity: 1;
 }
 .fet-tile--fade-out {
-  transform: translateY(150px);
+  transform: translateY(200px);
   opacity: 0;
 }
 .fet-tile--new .fet-tile__new-label {


### PR DESCRIPTION
1. Fixed "background image jumping" effect for mobile -when browser's address bar was hiding there was some empty space at the bottom of the page for a moment.
2. Improved fade-in and -out tile's animations: +50px to translateY creates smoother animations on mobile when connected with scroll animation after catgory choosing.
3. Renamed inspirational site name 'dribble' to correct 'dribbble'.